### PR TITLE
feat: Facility status

### DIFF
--- a/src/main/java/nl/wissehes/javatrain/DataStore.java
+++ b/src/main/java/nl/wissehes/javatrain/DataStore.java
@@ -5,6 +5,7 @@ import nl.wissehes.javatrain.mapper.JourneyMapper;
 import nl.wissehes.javatrain.mapper.PositionsMapper;
 import nl.wissehes.javatrain.model.NDOV.DVS.DepartureDocument;
 import nl.wissehes.javatrain.model.NDOV.RIT.JourneyDocument;
+import nl.wissehes.javatrain.model.SiriMessage;
 import nl.wissehes.javatrain.model.departure.Departure;
 import nl.wissehes.javatrain.model.departure.TrainStatus;
 import nl.wissehes.javatrain.model.journey.Journey;
@@ -34,6 +35,8 @@ public final class DataStore {
     private final List<String> rawPositions = new LinkedList<>();
 
     private final Map<String, Station> stations = new HashMap<>();
+
+    private final List<SiriMessage> rawSiriMessages = new LinkedList<>();
 
     private DataStore() {
     }
@@ -88,6 +91,13 @@ public final class DataStore {
     }
 
     /**
+     * Add a raw SIRI message to the data store
+     */
+    public void addRawSiriMessage(SiriMessage message) {
+        rawSiriMessages.add(message);
+    }
+
+    /**
      * Get the departures
      */
     public List<Departure> getDepartures() {
@@ -136,6 +146,10 @@ public final class DataStore {
      */
     public List<String> getRawPositions() {
         return rawPositions;
+    }
+
+    public List<SiriMessage> getRawSiriMessages() {
+        return rawSiriMessages;
     }
 
     /**

--- a/src/main/java/nl/wissehes/javatrain/ZmqConfig.java
+++ b/src/main/java/nl/wissehes/javatrain/ZmqConfig.java
@@ -3,15 +3,18 @@ package nl.wissehes.javatrain;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Service;
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
 import org.zeromq.ZMQ;
 
-@Configuration
+@Service
 public class ZmqConfig {
 
     @Value("${infoplus.endpoint}")
     private String ZMQ_SUBSCRIBER_ADDRESS;
+
+    private String SIRI_ADDRESS = "tcp://pubsub.besteffort.ndovloket.nl:7666";
 
     /** Departures */
     public static final String DVS_TOPIC = "/RIG/InfoPlusDVSInterface4";
@@ -22,8 +25,8 @@ public class ZmqConfig {
     /** Positions */
     public static final String POS_TOPIC = "/RIG/NStreinpositiesInterface5";
 
-    @Bean(destroyMethod = "close")
-    public ZMQ.Socket zmqSubscriber() {
+//    @Bean(destroyMethod = "close")
+    public ZMQ.Socket infoplusSubscriber() {
         ZContext context = new ZContext();
         ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
         subscriber.connect(ZMQ_SUBSCRIBER_ADDRESS);
@@ -31,6 +34,16 @@ public class ZmqConfig {
         subscriber.subscribe(DVS_TOPIC.getBytes(ZMQ.CHARSET));
         subscriber.subscribe(RIT_TOPIC.getBytes(ZMQ.CHARSET));
         subscriber.subscribe(POS_TOPIC.getBytes(ZMQ.CHARSET));
+
+        return subscriber;
+    }
+
+    public ZMQ.Socket siriSubscriber() {
+        ZContext context = new ZContext();
+        ZMQ.Socket subscriber = context.createSocket(SocketType.SUB);
+        subscriber.connect(SIRI_ADDRESS);
+
+        subscriber.subscribe("/".getBytes(ZMQ.CHARSET));
 
         return subscriber;
     }

--- a/src/main/java/nl/wissehes/javatrain/controller/SiriController.java
+++ b/src/main/java/nl/wissehes/javatrain/controller/SiriController.java
@@ -1,0 +1,38 @@
+package nl.wissehes.javatrain.controller;
+
+import nl.wissehes.javatrain.DataStore;
+import nl.wissehes.javatrain.model.SiriMessage;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/siri")
+public class SiriController {
+
+    private final DataStore dataStore;
+
+    public SiriController(DataStore dataStore) {
+        this.dataStore = dataStore;
+    }
+
+    @GetMapping(path = "/messages")
+    public List<SiriMessage> getMessages(@RequestParam(required = false) String topicFilter) {
+
+        if(topicFilter != null) {
+            return dataStore.getRawSiriMessages().stream()
+                    .filter(message -> message.topic().toLowerCase().contains(topicFilter.toLowerCase()))
+                    .toList();
+        }
+
+        return dataStore.getRawSiriMessages();
+    }
+
+    public SiriMessage getMessage(int index) {
+        return dataStore.getRawSiriMessages().get(index);
+    }
+
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/SiriMessageDocument.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/SiriMessageDocument.java
@@ -1,0 +1,19 @@
+package nl.wissehes.javatrain.model.SIRI;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import nl.wissehes.javatrain.model.SIRI.heartbeat.HeartbeatNotification;
+import nl.wissehes.javatrain.model.SIRI.service.ServiceDelivery;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement
+public class SiriMessageDocument {
+
+    @JacksonXmlProperty(localName = "ServiceDelivery")
+    public ServiceDelivery serviceDelivery;
+
+    @JacksonXmlProperty(localName = "HeartbeatNotification")
+    public HeartbeatNotification heartbeatNotification;
+
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/heartbeat/HeartbeatNotification.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/heartbeat/HeartbeatNotification.java
@@ -1,0 +1,30 @@
+package nl.wissehes.javatrain.model.SIRI.heartbeat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.time.OffsetDateTime;
+
+/*
+        <RequestTimestamp>2025-05-01T17:04:30+02:00</RequestTimestamp>
+        <ProducerRef>DOVA</ProducerRef>
+        <Status>true</Status>
+        <ServiceStartedTime>2025-05-01T16:09:49+02:00</ServiceStartedTime>
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HeartbeatNotification {
+
+    @JacksonXmlProperty(localName = "RequestTimestamp")
+    public OffsetDateTime requestTimestamp;
+
+    @JacksonXmlProperty(localName = "ProducerRef")
+    public String producerRef;
+
+    @JacksonXmlProperty(localName = "Status")
+    public boolean status;
+
+    @JacksonXmlProperty(localName = "ServiceStartedTime")
+    public OffsetDateTime serviceStartedTime;
+
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/package-info.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the necessary models for the SIRI messages.
+ */
+package nl.wissehes.javatrain.model.SIRI;

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/service/FacilityCondition.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/service/FacilityCondition.java
@@ -1,0 +1,29 @@
+package nl.wissehes.javatrain.model.SIRI.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.time.OffsetDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FacilityCondition {
+
+    @JacksonXmlProperty(localName = "FacilityRef")
+    public String facilityRef;
+
+    @JacksonXmlProperty(localName = "FacilityStatus")
+    public FacilityStatus facilityStatus;
+
+    @JacksonXmlProperty(localName = "ValidityPeriod")
+    public ValidityPeriod validityPeriod;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record FacilityStatus(
+            @JacksonXmlProperty(localName = "Status") String status
+    ) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ValidityPeriod(
+            @JacksonXmlProperty(localName = "StartTime") OffsetDateTime startTime
+    ) { }
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/service/FacilityMonitoringDelivery.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/service/FacilityMonitoringDelivery.java
@@ -1,0 +1,20 @@
+package nl.wissehes.javatrain.model.SIRI.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FacilityMonitoringDelivery {
+
+    @JacksonXmlProperty(localName = "ResponseTimestamp")
+    public LocalDateTime timestamp;
+
+    @JacksonXmlProperty(localName = "FacilityCondition")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    public List<FacilityCondition> facilityCondition;
+
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SIRI/service/ServiceDelivery.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SIRI/service/ServiceDelivery.java
@@ -1,0 +1,20 @@
+package nl.wissehes.javatrain.model.SIRI.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import java.time.OffsetDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceDelivery {
+
+    @JacksonXmlProperty(localName = "ResponseTimestamp")
+    public OffsetDateTime timestamp;
+
+    @JacksonXmlProperty(localName = "ProducerRef")
+    public String producerRef;
+
+    @JacksonXmlProperty(localName = "FacilityMonitoringDelivery")
+    public FacilityMonitoringDelivery facilityMonitoringDelivery;
+
+}

--- a/src/main/java/nl/wissehes/javatrain/model/SiriMessage.java
+++ b/src/main/java/nl/wissehes/javatrain/model/SiriMessage.java
@@ -1,0 +1,7 @@
+package nl.wissehes.javatrain.model;
+
+public record SiriMessage(
+        String topic,
+        String message
+) {
+}


### PR DESCRIPTION
I want to add Lift statusses. The data delivered by DOVA/SIRI contains a `facilityRef` made up of the station's UIC code and the lift number, for example: `NL:CHB:LiftEquipment:8400114_003`. This is not ideal. I could however lookup the UIC code in the saved stations and then match the lift code in the Liften csv file (https://data.ndovloket.nl/prorail/?order=D).